### PR TITLE
Make variable names concise and consistent

### DIFF
--- a/pct-shiny-funs.R
+++ b/pct-shiny-funs.R
@@ -55,8 +55,8 @@ zoneColNames <- c(
 )
 
 scenariosNames <- c(
-  "olc"      = "Cycle commuters (recorded)",
-  "slc"      = "Cycle commuters (scenario)"
+  "olc"      = "Cyclists (recorded)",
+  "slc"      = "Cyclists (scenario)"
 )
 
 # Normalise the data ready for plotting
@@ -85,11 +85,11 @@ tableCommon <- '<tr>
 <td> %s </td>
 </tr>
 <tr>
-<td>Cycle commuters (recorded):  </td>
+<td>Cyclists (recorded):  </td>
 <td> %s (%s&#37;)</td>
 </tr>
 <tr>
-<td>Cycle commuters (scenario):  </td>
+<td>Cyclists (scenario):  </td>
 <td> %s </td>
 </tr>
 '
@@ -100,11 +100,11 @@ tableOLC <- '<tr>
 <td>  %s </td>
 </tr>
 <tr>
-<td>Cycle commuters (recorded):  </td>
+<td>Cyclists (recorded):  </td>
 <td>  %s (%s&#37;)</td>
 </tr>
 <tr>
-<td>Car commuters (recorded):    </td>
+<td>Drivers (recorded):    </td>
 <td>  %s </td>
 </tr>
 '
@@ -193,7 +193,7 @@ networkRoutePopup <- function(data, scenario){
   if(scenario == 'olc') {
 
     tableInterm <-sprintf(paste('<tr>
-                  <td>Cycle commuters (recorded):&nbsp</td>
+                  <td>Cyclists (recorded):&nbsp</td>
                   <td> %s </td>
                   </tr>'),
                   data$Bicycle)
@@ -202,11 +202,11 @@ networkRoutePopup <- function(data, scenario){
       else {
 
         tableInterm <-sprintf(paste('<tr>
-                  <td>Cycle commuters (recorded):&nbsp</td>
+                  <td>Cyclists (recorded):&nbsp</td>
                   <td> %s </td>
                   </tr>
                   <tr>
-                  <td>Cycle commuters (scenario):&nbsp</td>
+                  <td>Cyclists (scenario):&nbsp</td>
                   <td> %s </td>
                   </tr>'),
                   data$Bicycle, round(data[[dataFilter(scenario, "slc")]]))
@@ -237,7 +237,7 @@ zonePopup <- function(data, scenario, zone){
                           <td>%s </td>
                           </tr>
                           <tr>
-                          <td>Car commuters (recorded):    </td>
+                          <td>Drivers (recorded):    </td>
                           <td>%s </td>
                           </tr>
                           <tr>
@@ -257,7 +257,7 @@ zonePopup <- function(data, scenario, zone){
                         <td>%s</td>
                         </tr>
                         <tr>
-                        <td>Cycle commuters (recorded):  </td>
+                        <td>Cyclists (recorded):  </td>
                         <td>%s </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Please test this @audev and liaise with @JDWoodcock: the updated names are silly long, clutter up space and duplicate information (we say it's commters in the 2011 census in the key and other places - no need to say it for every line).

Plus this update will make it easier to add new layers that are not based on the 2011 Census (e.g. Manchester) - it will make our code more portable.

Before this PR: 

![selection_081](https://cloud.githubusercontent.com/assets/1825120/13282550/6cadeee4-dae1-11e5-83ed-bf195fdbaabc.png)


After:

![selection_080](https://cloud.githubusercontent.com/assets/1825120/13282513/45db746c-dae1-11e5-9a00-95a94c534466.png)
