### PR TITLE
Fix returning to map tab when bounds are null

### DIFF
--- a/server-base.R
+++ b/server-base.R
@@ -104,6 +104,7 @@ shinyServer(function(input, output, session){
   # Select and sort lines within a bounding box - given by flowsBB()
   sortLines <- function(lines, sortBy, nos){
     poly <- flowsBB()
+    if(is.null(poly)) return(NULL)
     poly <- spTransform(poly, CRS(proj4string(lines)))
     keep <- gContains(poly, lines,byid=TRUE )
     if(all(!keep)) return(NULL)


### PR DESCRIPTION
This was causing crashes when changing tabs
as the map bounds was momentarily null.