### PR TITLE
Export all lines in geojson

### DIFF
--- a/server-base.R
+++ b/server-base.R
@@ -459,8 +459,14 @@ shinyServer(function(input, output, session){
     # the argument 'file'.
     content = function(file) {
       # Bug in writeOGR that there can be no "." in the file name
+      output <- switch(input$line_type,
+                       'straight' = toPlot$l,
+                       'route'    = toPlot$rQuiet,
+                       'd_route'  = toPlot$rFast,
+                       'rnet'     = toPlot$rnet
+      )
       fileNoDot <- unlist(strsplit(file, ".", fixed = T))[1]
-      writeOGR(toPlot$ldata, dsn = fileNoDot, layer = "", driver='GeoJSON', overwrite_layer= T)
+      writeOGR(output, dsn = fileNoDot, layer = "", driver='GeoJSON', overwrite_layer= T)
       file.rename(fileNoDot, file)
     }
   )


### PR DESCRIPTION
Closes #211 (NOTE: only exports quite lines when both are shown)

@Robinlovelace you might be able to get `rbind` to work but its just black magic to me, the ids clash, then the numbers of columns of arguments do not match then the row.names of data and Lines IDs don't match.  :confounded: 