### PR TITLE
Hide and show centroids depending on the zoom level. 

### DIFF
--- a/server-base.R
+++ b/server-base.R
@@ -215,11 +215,10 @@ shinyServer(function(input, output, session){
     region$replot
     input$map_base
     zoom_multiplier <- get_zone_multiplier(input$map_zoom)
-    clearGroup(leafletProxy("map"), "centres")
-    if(input$map_zoom < 9 || isolate(input$line_type) == 'none') return()
-    addCircleMarkers(leafletProxy("map"), data = to_plot$cents, radius = (to_plot$cents$All* zoom_multiplier) / mean(to_plot$cents$All) ,
-                       color = get_line_colour("centres"), group = "centres", opacity = 0.5,
-                       popup = centroid_popup(to_plot$cents, input$scenario, zone_attr()))
+    if(input$map_zoom < 11 || isolate(input$line_type) == 'none')
+      hideGroup(leafletProxy("map"), "centres")
+    else
+      showGroup(leafletProxy("map"), "centres")
   })
 
   observe({
@@ -239,6 +238,9 @@ shinyServer(function(input, output, session){
                   , options = pathOptions(clickable = show_zone_popup)
                   , layerId = paste0(to_plot$zones[['geo_code']], '-', "zones")) %>%
       addCircleMarkers(., radius=0, lat=0, lng=0, group = "region_name", fillOpacity= 0, layerId = region$current) %>%
+      addCircleMarkers(., data = to_plot$cents, radius = to_plot$cents$All / mean(to_plot$cents$All) * 2 + 1,
+                       color = get_line_colour("centres"), group = "centres", opacity = 0.5,
+                       popup = centroid_popup(to_plot$cents, input$scenario, zone_attr())) %>%
       # Hide and Show line layers, so that they are displayed as the top layer in the map.
       # Leaflet's function bringToBack() or bringToFront() (see http://leafletjs.com/reference.html#path)
       # don't seem to exist for R


### PR DESCRIPTION
Instead of redrawing centroids on zoom level, it's better to hide them when zoomed out. It improves the performance of the app as well. What do you guys @Robinlovelace and @nikolai-b think?
