### PR TITLE
Remove school NAs on Rds load

### DIFF
--- a/regions_www/m/pct_shiny_funs.R
+++ b/regions_www/m/pct_shiny_funs.R
@@ -20,6 +20,14 @@ get_pretty_region_name <- function(region_name_in, the = T){
   }
 }
 
+## Return a named list with the possible NAs columns and the base column to replace them,
+## i.e. govtarget_slc NAs should be replaced with 3 + govtarget_sic
+school_na <- function(scenario){
+  list(
+    na   = c(paste0(scenario, "_slc"), paste0(scenario, "_slw"), paste0(scenario, "_sld")),
+    base = c(paste0(scenario, "_sic"), paste0(scenario, "_siw"), paste0(scenario, "_sid"))
+  )
+}
 
 ## Normalise the data ready for plotting (used for centroid sizes and line widths)
 normalise <- function(values, min = 0, max = 1){

--- a/regions_www/m/server.R
+++ b/regions_www/m/server.R
@@ -310,6 +310,14 @@ shinyServer(function(input, output, session) {
       to_plot$route_network$id <<- to_plot$route_network$local_id
     }
 
+    # For confidentiality we have replaced exact numbers with NAs but they cause havoc with the interface.
+    # This replaces the NAs with the mean values.
+    if (input$purpose == "school") {
+      to_plot$zones@data[is.na(to_plot$zones@data)] <<- 1.5
+      to_plot$route_network@data[is.na(to_plot$zones@data)] <<- 1.5
+      to_plot$destinations@data[is.na(to_plot$destinations@data)] <<- 3
+    }
+
     if (file.exists(file.path(region$data_dir, "rq.Rds"))) {
       to_plot$routes_quieter <<- readRDS(file.path(region$data_dir, "rq.Rds"))
       # Merge in scenario data for quiet routes - don't want this in download but need for line sorting

--- a/regions_www/m/server.R
+++ b/regions_www/m/server.R
@@ -319,29 +319,27 @@ shinyServer(function(input, output, session) {
       d_na_const <- 3
       rnet_na_const <- 1.5
 
-      to_plot$zones@data[,columns_na][
-        is.na(to_plot$zones@data[,columns_na])
-      ] <<- z_na_const
+      idx <- is.na(to_plot$zones@data[,columns_na])
+      to_plot$zones@data[,columns_na][idx] <<- z_na_const
 
-      to_plot$zones@data[,school_na("govtarget")$na][
-        is.na(to_plot$zones@data[,school_na("govtarget")$na])
-      ] <<- z_na_const + to_plot$zones@data[,school_na("govtarget")$base]
+      idx <- is.na(to_plot$zones@data[,school_na("govtarget")$na])
+      to_plot$zones@data[,school_na("govtarget")$na][idx] <<- z_na_const +
+        to_plot$zones@data[,school_na("govtarget")$base][idx]
 
-      to_plot$zones@data[,school_na("dutch")$na][
-        is.na(to_plot$zones@data[,school_na("dutch")$na])
-      ] <<- z_na_const + to_plot$zones@data[,school_na("dutch")$base]
+      idx <- is.na(to_plot$zones@data[,school_na("dutch")$na])
+      to_plot$zones@data[,school_na("dutch")$na][idx] <<- z_na_const +
+        to_plot$zones@data[,school_na("dutch")$base][idx]
 
-      to_plot$destinations@data[,columns_na][
-        is.na(to_plot$destinations@data[,columns_na])
-      ] <<- d_na_const
+      idx <- is.na(to_plot$destinations@data[,columns_na])
+      to_plot$destinations@data[,columns_na][idx] <<- d_na_const
 
-      to_plot$destinations@data[,school_na("govtarget")$na][
-        is.na(to_plot$destinations@data[,school_na("govtarget")$na])
-      ] <<- d_na_const + to_plot$destinations@data[,school_na("govtarget")$base]
+      idx <- is.na(to_plot$destinations@data[,school_na("govtarget")$na])
+      to_plot$destinations@data[,school_na("govtarget")$na][idx] <<- d_na_const +
+        to_plot$destinations@data[,school_na("govtarget")$base][idx]
 
-      to_plot$destinations@data[,school_na("dutch")$na][
-        is.na(to_plot$destinations@data[,school_na("dutch")$na])
-      ] <<- d_na_const + to_plot$destinations@data[,school_na("dutch")$base]
+      idx <- is.na(to_plot$destinations@data[,school_na("dutch")$na])
+      to_plot$destinations@data[,school_na("dutch")$na][idx] <<- d_na_const +
+        to_plot$destinations@data[,school_na("dutch")$base][idx]
 
       to_plot$route_network@data[is.na(to_plot$route_network@data)] <<- rnet_na_const
     }

--- a/regions_www/m/server.R
+++ b/regions_www/m/server.R
@@ -314,7 +314,7 @@ shinyServer(function(input, output, session) {
     # This replaces the NAs with the mean values.
     if (input$purpose == "school") {
       to_plot$zones@data[is.na(to_plot$zones@data)] <<- 1.5
-      to_plot$route_network@data[is.na(to_plot$zones@data)] <<- 1.5
+      to_plot$route_network@data[is.na(to_plot$route_network@data)] <<- 1.5
       to_plot$destinations@data[is.na(to_plot$destinations@data)] <<- 3
     }
 

--- a/regions_www/m/server.R
+++ b/regions_www/m/server.R
@@ -313,9 +313,37 @@ shinyServer(function(input, output, session) {
     # For confidentiality we have replaced exact numbers with NAs but they cause havoc with the interface.
     # This replaces the NAs with the mean values.
     if (input$purpose == "school") {
-      to_plot$zones@data[is.na(to_plot$zones@data)] <<- 1.5
-      to_plot$route_network@data[is.na(to_plot$route_network@data)] <<- 1.5
-      to_plot$destinations@data[is.na(to_plot$destinations@data)] <<- 3
+      columns_na <- c("all", "bicycle", "foot", "car")
+
+      z_na_const <- 1.5
+      d_na_const <- 3
+      rnet_na_const <- 1.5
+
+      to_plot$zones@data[,columns_na][
+        is.na(to_plot$zones@data[,columns_na])
+      ] <<- z_na_const
+
+      to_plot$zones@data[,school_na("govtarget")$na][
+        is.na(to_plot$zones@data[,school_na("govtarget")$na])
+      ] <<- z_na_const + to_plot$zones@data[,school_na("govtarget")$base]
+
+      to_plot$zones@data[,school_na("dutch")$na][
+        is.na(to_plot$zones@data[,school_na("dutch")$na])
+      ] <<- z_na_const + to_plot$zones@data[,school_na("dutch")$base]
+
+      to_plot$destinations@data[,columns_na][
+        is.na(to_plot$destinations@data[,columns_na])
+      ] <<- d_na_const
+
+      to_plot$destinations@data[,school_na("govtarget")$na][
+        is.na(to_plot$destinations@data[,school_na("govtarget")$na])
+      ] <<- d_na_const + to_plot$destinations@data[,school_na("govtarget")$base]
+
+      to_plot$destinations@data[,school_na("dutch")$na][
+        is.na(to_plot$destinations@data[,school_na("dutch")$na])
+      ] <<- d_na_const + to_plot$destinations@data[,school_na("dutch")$base]
+
+      to_plot$route_network@data[is.na(to_plot$route_network@data)] <<- rnet_na_const
     }
 
     if (file.exists(file.path(region$data_dir, "rq.Rds"))) {


### PR DESCRIPTION
@AnnaGoodman1 can we not avoid the `school` data and use the `school_download` data instead?

That would mean any change in the downloads would always be reflected in the interface (and vice versa).  Having two different files leads the the possibility that they become out of sync.