### PR TITLE
Fix issue with deployment script

### DIFF
--- a/scripts/shiny-control
+++ b/scripts/shiny-control
@@ -33,7 +33,7 @@ my @shinyDeploy =  ("${scriptsFolder}deploy-shiny", "/usr/local/sbin/deploy-shin
 
 if( (compare(@shinyConf) != 0) || (compare(@shinyService) != 0) || (compare(@shinyDeploy) != 0) ) {
   my $nShinys = scalar @shinys || 2;
-  print "Shiny server deployment, config or service has changed, regenerating shiny services with $nShinys shiny server instances\n\n"
+  print "Shiny server deployment, config or service has changed, regenerating shiny services with $nShinys shiny server instances\n\n";
   copy(@shinyConf);
   copy(@shinyService);
   copy(@shinyDeploy);

--- a/scripts/shiny-server.service
+++ b/scripts/shiny-server.service
@@ -5,7 +5,6 @@ Description=ShinyServerSHINYN
 Type=simple
 ExecStart=/bin/bash -c '/opt/shiny-server/bin/shiny-server --pidfile=/var/run/shiny-server-SHINYN.pid /etc/shiny-server/shiny-server-SHINYN.conf >> /var/log/shiny-server-SHINYN.log 2>&1'
 # Needed to give SS a chance to write out to the PID file.
-ExecStartPost=/bin/sleep 3
 PIDFile=/var/run/shiny-server-SHINYN.pid
 KillMode=process
 Environment="LANG=en_GB.UTF-8"


### PR DESCRIPTION
I noticed two issues when we deployed, this fixes them:

Fix invalid perl, tweak systemd as we were getting:
Jul 12 18:48:43 npt2 systemd[1]: shiny-server0.service: Supervising process 465 which is not our child. We'll most likely not notice when it exits.