### PR TITLE
Add IE compatability tag

### DIFF
--- a/regions_www/m/ui.R
+++ b/regions_www/m/ui.R
@@ -75,7 +75,8 @@ shinyUI(
           if(on_server) includeScript("../www/assets/google-analytics.js"),
           includeScript("../www/assets/extra.js"),
           includeCSS("../www/stylesheet.css"),
-          includeHTML(file.path("..", "favicon.html"))
+          includeHTML(file.path("..", "favicon.html")),
+          tags$meta("http-equiv" = "X-UA-Compatible", content="IE=edge")
         ),
         includeHTML(file.path("..", "www", "test-banner.html")),
         div(id="loading", "Loading&#8230;"),


### PR DESCRIPTION
Should stop IE from rendering the site in compatability mode
Fixes #791

Note for testing: the site works and this tag is recommended, without we get an error in this [html checker](https://validator.w3.org/nu/?showsource=yes&doc=http%3A%2F%2Fnpct0.vs.mythic-beasts.com%2Fm%2F%3Fr%3Disle-of-wight), see [stack exchange](https://stackoverflow.com/questions/6771258/what-does-meta-http-equiv-x-ua-compatible-content-ie-edge-do) for more.