### PR TITLE
Fix: allow R to be restarted

### DIFF
--- a/scripts/shiny-server.service
+++ b/scripts/shiny-server.service
@@ -3,11 +3,8 @@ Description=ShinyServerSHINYN
 
 [Service]
 Type=simple
-ExecStart=/bin/bash -c '/opt/shiny-server/bin/shiny-server --pidfile=/var/run/shiny-server-SHINYN.pid /etc/shiny-server/shiny-server-SHINYN.conf >> /var/log/shiny-server-SHINYN.log 2>&1'
-# Needed to give SS a chance to write out to the PID file.
-PIDFile=/var/run/shiny-server-SHINYN.pid
+ExecStart=/usr/bin/env bash -c '/opt/shiny-server/bin/shiny-server /etc/shiny-server/shiny-server-SHINYN.conf >> /var/log/shiny-server-SHINYN.log 2>&1'
 KillMode=process
-Environment="LANG=en_GB.UTF-8"
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 ExecStopPost=/usr/bin/env sleep 5
 Restart=on-failure


### PR DESCRIPTION
The OOM killer (or other process) have been killing R
and systemd restarts it BUT if we manually pass the pidfile
in then it seems like the parent process doesn't pick up the
restarted R.

Fixes #800