### PR TITLE
Stability

### DIFF
--- a/regions_www/m/server.R
+++ b/regions_www/m/server.R
@@ -234,9 +234,11 @@ shinyServer(function(input, output, session) {
     # Rm objects (by time last accessed) if the list size is more than 2 Gb
     if (format(object.size(loaded_data), units = "Gb") > 2) {
       idx_to_rm <- which(loaded_data_accessed == min(unlist(loaded_data_accessed)))
-      print(c("removing", dir_to_rm, format(object.size(loaded_data), units = "Gb")))
-      loaded_data[[idxes_to_rm]] <<- NULL
-      loaded_data_accessed[[idxes_to_rm]] <<- NULL
+      if (interactive()){
+        print(c("removing", names(loaded_data)[[idx_to_rm]], format(object.size(loaded_data), units = "Gb")))
+      }
+      loaded_data[[idx_to_rm]] <<- NULL
+      loaded_data_accessed[[idx_to_rm]] <<- NULL
     }
 
     if (file.exists(filepath)) {

--- a/scripts/shiny-server.service
+++ b/scripts/shiny-server.service
@@ -3,7 +3,7 @@ Description=ShinyServerSHINYN
 
 [Service]
 Type=simple
-ExecStart=/usr/bin/env bash -c '/opt/shiny-server/bin/shiny-server /etc/shiny-server/shiny-server-SHINYN.conf >> /var/log/shiny-server-SHINYN.log 2>&1'
+ExecStart=/usr/bin/env bash -c 'exec /opt/shiny-server/bin/shiny-server /etc/shiny-server/shiny-server-SHINYN.conf >> /var/log/shiny-server-SHINYN.log 2>&1'
 KillMode=process
 ExecReload=/usr/bin/env kill -HUP $MAINPID
 ExecStopPost=/usr/bin/env sleep 5


### PR DESCRIPTION
I broke object removal in 94bb365, this fixes that and also I noticed systemd can't restart shiny-server as it has forked so we should use `exec`.